### PR TITLE
Build shared object with version information

### DIFF
--- a/src/concurrent/wscript
+++ b/src/concurrent/wscript
@@ -19,6 +19,7 @@ def build(bld):
     source = 'thread.cpp mutex.cpp rwmutex.cpp condition.cpp internal.cpp',
     target = 'pficommon_concurrent',
     includes = '.',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_system PTHREAD')
 
   bld.program(

--- a/src/data/wscript
+++ b/src/data/wscript
@@ -61,6 +61,7 @@ def build(bld):
       ],
     target = 'pficommon_data',
     includes = incdirs,
+    vnum = bld.env['VERSION'],
     use = 'pficommon_system')
 
   def t(src):

--- a/src/database/mysql/wscript
+++ b/src/database/mysql/wscript
@@ -7,4 +7,5 @@ def build(bld):
     source = 'connection.cpp statement.cpp value.cpp',
     target = 'pficommon_database_mysql',
     includes = '. ..',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_concurrent MYSQL')

--- a/src/database/postgresql/wscript
+++ b/src/database/postgresql/wscript
@@ -7,4 +7,5 @@ def build(bld):
     source = 'connection.cpp statement.cpp result.cpp value.cpp',
     target = 'pficommon_database_postgresql',
     includes = '. ..',
+    vnum = bld.env['VERSION'],
     use = 'PGSQL')

--- a/src/database/wscript
+++ b/src/database/wscript
@@ -44,6 +44,7 @@ def build(bld):
   t = bld.shlib(
     source = '',
     target = 'pficommon_database',
+    vnum = bld.env['VERSION'],
     use = [])
   
   if bld.env.BUILD_MYSQL:

--- a/src/lang/wscript
+++ b/src/lang/wscript
@@ -20,6 +20,7 @@ def build(bld):
 
   bld.shlib(
     source = 'empty.cpp',
+    vnum = bld.env['VERSION'],
     target = 'pficommon_lang')
 
   bld.program(

--- a/src/math/wscript
+++ b/src/math/wscript
@@ -14,6 +14,7 @@ def build(bld):
   bld.shlib(
     source = 'random/mersenne_twister.cpp',
     target = 'pficommon_math',
+    vnum = bld.env['VERSION'],
     includes = '.')
   
   def t(src):

--- a/src/network/cgi/wscript
+++ b/src/network/cgi/wscript
@@ -47,6 +47,7 @@ def build(bld):
     source = 'base.cpp xhtml_cgi.cpp xhtml_builder.cpp inserter.cpp cgi.cpp server.cpp util.cpp',
     target = 'pficommon_network_cgi',
     includes = '. ..',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_text pficommon_concurrent pficommon_network_http PTHREAD')
 
   if bld.env.BUILD_FCGI:

--- a/src/network/http/wscript
+++ b/src/network/http/wscript
@@ -14,4 +14,5 @@ def build(bld):
     source = 'base.cpp',
     target = 'pficommon_network_http',
     includes = '. ..',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_network_base')

--- a/src/network/mprpc/wscript
+++ b/src/network/mprpc/wscript
@@ -21,4 +21,5 @@ def build(bld):
       'socket.cpp'
       ],
     target = 'pficommon_network_mprpc',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_concurrent pficommon_network_base MSGPACK')

--- a/src/network/rpc/wscript
+++ b/src/network/rpc/wscript
@@ -17,4 +17,5 @@ def build(bld):
     source = 'base.cpp',
     target = 'pficommon_network_rpc',
     includes = '. ..',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_network_base pficommon_concurrent pficommon_system')

--- a/src/network/wscript
+++ b/src/network/wscript
@@ -56,11 +56,13 @@ def build(bld):
     source = 'socket.cpp ipv4.cpp dns.cpp uri.cpp',
     target = 'pficommon_network_base',
     includes = '.',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_concurrent')
   
   pfin = bld.shlib(
     source = '',
     target = 'pficommon_network',
+    vnum = bld.env['VERSION'],
     use = [
       'pficommon_network_base',
       'pficommon_network_http',

--- a/src/system/wscript
+++ b/src/system/wscript
@@ -21,6 +21,7 @@ def build(bld):
       'sysstat.cpp',
       'mmapper.cpp'],
     target = 'pficommon_system',
+    vnum = bld.env['VERSION'],
     includes = '.')
 
   bld.program(

--- a/src/text/wscript
+++ b/src/text/wscript
@@ -16,6 +16,7 @@ def build(bld):
     source = 'xhtml.cpp csv.cpp json/parser.cpp',
     target = 'pficommon_text',
     includes = '. json',
+    vnum = bld.env['VERSION'],
     use = 'pficommon_data pficommon_system')
   
   bld.program(

--- a/src/util/wscript
+++ b/src/util/wscript
@@ -8,6 +8,7 @@ def build(bld):
   
   bld.shlib(
     source = '',
+    vnum = bld.env['VERSION'],
     target = 'pficommon_util')
   
   bld(features = 'cxx cprogram gtest',

--- a/src/visualization/wscript
+++ b/src/visualization/wscript
@@ -27,6 +27,7 @@ def build(bld):
   v = bld.shlib(
     source = ['empty.cpp'],
     target = 'pficommon_visualization',
+    vnum = bld.env['VERSION'],
     use =  [])
   
   bld.program(

--- a/src/wscript
+++ b/src/wscript
@@ -26,6 +26,7 @@ def build(bld):
   b = bld.shlib(
     source = 'empty.cpp',
     target = 'pficommon',
+    vnum = bld.env['VERSION'],
     use = [
       'pficommon_concurrent',
       'pficommon_data',


### PR DESCRIPTION
This patch change the libraries to be built with version
information. Also it set libraries' SONAME propery.
