### PR TITLE
Fix indent error of fcgi detection code

### DIFF
--- a/src/network/cgi/wscript
+++ b/src/network/cgi/wscript
@@ -25,12 +25,12 @@ def configure(conf):
                         uselib_store = 'FCGI',
                         mandatory = False):
         conf.env.BUILD_FCGI = True
-      else:
-        if conf.check_cxx(lib = 'fcgi',
-                          header_name = 'fcgiapp.h',
-                          uselib_store = 'FCGI',
-                          mandatory = False):
-          conf.env.BUILD_FCGI = True
+    else:
+      if conf.check_cxx(lib = 'fcgi',
+                        header_name = 'fcgiapp.h',
+                        uselib_store = 'FCGI',
+                        mandatory = False):
+        conf.env.BUILD_FCGI = True
 
 def build(bld):
   bld.install_files('${HPREFIX}/network/cgi', [


### PR DESCRIPTION
--with-fcgiでなにかしら指定しないとfcgiのライブラリ・ヘッダの検出
が行なわれずfcgiの機能が無効になっています。msgpackの検出ルーチン
と同じようなインデントになるように修正しています。

fcgi feature was disabled without --with-fcgi=somthing argument. This
patch correct its indent to try to find fcgi library and header file
from compiler default search path.
