### PR TITLE
Solved the pficommon.json's bad_cast problem.

### DIFF
--- a/src/text/json_test.cpp
+++ b/src/text/json_test.cpp
@@ -525,6 +525,16 @@ TEST(json, optional)
 	opt1 a; iss>>via_json(a);
       },
       std::bad_cast);
+    EXPECT_THROW({
+	istringstream iss("{}");
+	opt1 a; iss>>via_json(a);
+      },
+      json_bad_cast_any);
+    EXPECT_THROW({
+	istringstream iss("{\"def\": 456}");
+	opt1 a; iss>>via_json(a);
+      },
+      json_bad_cast_any);
   }
   {
     opt1 a;


### PR DESCRIPTION
json_cast and other functions throw json_bad_cast<T> instead of bad_cast.

try {
  json_cast<int>(j);
} catch (json_bad_cast<int>& e) {
  // ...
}

json_bad_cast is derived from bad_cast, so the modification does not break existing codes.

try {
  json_cast<int>(j);
} catch (std::bad_cast& e) {
  // ...
}

You can also use json_bad_cast_any instead of json_bad_cast for convenience.

try {
  json_cast<int>(j);
} catch (json_bad_cast_any& e) {
  // ...
}
