### PR TITLE
Fixed json_cast goes infinite recursion

### DIFF
--- a/src/text/json/cast.h
+++ b/src/text/json/cast.h
@@ -65,14 +65,28 @@ template <class T>
 T json_cast_with_default(const json &js, const T &def = T());
 
 template <>
-inline int64_t json_cast_impl(const json &js)
+inline long int json_cast_impl(const json &js)
 {
   const json_integer &p=dynamic_cast<const json_integer&>(*js.get());
   return p.get();
 }
 
 template <>
-inline int64_t json_cast_with_default(const json &js, const int64_t &def)
+inline long int json_cast_with_default(const json &js, const long int &def)
+{
+  const json_integer *p=dynamic_cast<const json_integer*>(js.get());
+  return p?p->get():def;
+}
+
+template <>
+inline long long int json_cast_impl(const json &js)
+{
+  const json_integer &p=dynamic_cast<const json_integer&>(*js.get());
+  return p.get();
+}
+
+template <>
+inline long long int json_cast_with_default(const json &js, const long long int &def)
 {
   const json_integer *p=dynamic_cast<const json_integer*>(js.get());
   return p?p->get():def;

--- a/src/text/json_test.cpp
+++ b/src/text/json_test.cpp
@@ -234,6 +234,8 @@ TEST(json, from_json)
   {
     json j(new json_integer(123));
     EXPECT_EQ(123, json_cast<int>(j));
+    EXPECT_EQ(123, json_cast<long int>(j));
+    EXPECT_EQ(123, json_cast<long long int>(j));
   }
   {
     json j(new json_float(3.14));


### PR DESCRIPTION
- template<> long int json_cast_impl(const json &js)
- template<> long long int json_cast_impl(const json &js)

以上の関数がsrc/text/cast.hに定義されていないため、
以下のコードでjson_cast_implとserialize間で無限再帰に陥ります。
long intやlong long intに対するserialize関数は定義されているため、コンパイルは正常に通ります。また、64ビット環境のGCCではint64_tはlong long intでtypedefされているようなので、int/long/long long用のキャストを用意して、利用者側でint64_tでも利用できるようになれば良いのかと提案してみます。

``` cpp
json j(new json_integer(123));
json_cast<long int>(j);
json_cast<long long int>(j);
```

Linux x86_64, Mac OS X(32ビットコンパイルオプション)環境にてコンパイル及びテストが通ることを確認しました。
