### PR TITLE
Removed warnings generated when compiling pficommon using Intel C++ compiler.

### DIFF
--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -58,10 +58,6 @@ namespace string {
 
     ustring(const std::basic_string<uchar> &str)
       : std::basic_string<uchar>(str) {}
-
-    operator std::basic_string<uchar>() const {
-      return std::basic_string<uchar>(*this);
-    }
   };
   
   // string <-> ustring conversion
@@ -112,7 +108,7 @@ namespace string {
   template <class OutputIterator>
   void uchar_to_chars(uchar c, OutputIterator &out){
     char b;
-    if(0 <= c && c <= 0x007f){
+    if(c <= 0x007f){
       b = c;
       *out++ = b;
     }else if(0x0080 <= c && c <= 0x07ff){

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -425,7 +425,7 @@ int stream_socket::buf_elem()
 
 server_socket::server_socket()
   : sock(-1)
-  , port_num(-1)
+  , port_num(~uint16_t())
   , timeout_sec(-1)
   , connected(false)
 {

--- a/src/visualization/color.h
+++ b/src/visualization/color.h
@@ -54,7 +54,7 @@ struct rgb{
 
 
 template <class quantum>
-const bool operator==(const rgb<quantum> &a,const rgb<quantum> &x){
+bool operator==(const rgb<quantum> &a,const rgb<quantum> &x){
   return x.r==a.r && x.g==a.g && x.b==a.b;
 }
 

--- a/src/visualization/ppm.h
+++ b/src/visualization/ppm.h
@@ -73,19 +73,19 @@ public:
   /// return color of out of range
   color::rgb<quantum> bgcolor; 
 
-  const image_coordinate_t width() const{return w;}
+  image_coordinate_t width() const{return w;}
 
-  const image_coordinate_t height() const{return h;}
+  image_coordinate_t height() const{return h;}
   
-  const bool in(const image_coordinate_t &x, const image_coordinate_t &y) const{ 
+  bool in(const image_coordinate_t &x, const image_coordinate_t &y) const{ 
     return x>=0 && y>=0 && x<w && y<h;
   }
   template<class r>
-  const bool in(const pfi::math::vector::component_by_name::vector2<r> &p) const{
+  bool in(const pfi::math::vector::component_by_name::vector2<r> &p) const{
     return in((image_coordinate_t)p.x, (image_coordinate_t)p.y);
   }
   template<class r>
-  const bool in(const std::complex<r> &p) const{
+  bool in(const std::complex<r> &p) const{
     return in((image_coordinate_t)p.real(), (image_coordinate_t)p.imag());
   }
 


### PR DESCRIPTION
Replaced -1 with ~uint16_t()
Removed redundant consts
Removed never used conversion function
Removed a comparison which is always true
