### PR TITLE
Fixed wscript not to build mysql module when mysql-devel package is not installed

### DIFF
--- a/src/database/wscript
+++ b/src/database/wscript
@@ -15,7 +15,8 @@ def configure(conf):
                       package = '',
                       uselib_store = 'MYSQL',
                       mandatory = False):
-      if conf.check_cxx(header_name = 'mysql/mysql.h',
+      if conf.check_cxx(header_name = 'mysql.h',
+                        use = 'MYSQL',
                         mandatory = False):
         conf.env.BUILD_MYSQL = True
 


### PR DESCRIPTION
The mysql package provide mysql_config but does not provide mysql/mysql.h.
Mysql header are provided by mysql-devel package, so we should check also the header.

Before applying this patch, compilation was failed in the environment which mysql package is installed but mysql-devel package is not installed. Of course, we can avoid those error by using --disable-database option when executing waf configure :)

I have tested this patch in CentOS 5.7, confirmed that compilation succeeded in following two situation.

When only mysql package is installed, pficommon's mysql module is not build:

<pre>
...
Checking for 'mysql_config'              : yes
Checking for header mysql/mysql.h        : not found

pficommon has been configured as follows:

[Modules]
FCGI module:             no
Database module:         yes
  have MySQL lib:          no
  have PostgreSQL lib:     no
...
</pre>


When mysql and mysql-devel packages are installed, pficommon's mysql module is build:

<pre>
...
Checking for 'mysql_config'              : yes
Checking for header mysql/mysql.h        : yes

pficommon has been configured as follows:

[Modules]
FCGI module:             no
Database module:         yes
  have MySQL lib:          yes
  have PostgreSQL lib:     no
...
</pre>
