### PR TITLE
Fixed the type of shared_ptr::operator ='s return value (removed "<T>")

### DIFF
--- a/src/lang/shared_ptr.h
+++ b/src/lang/shared_ptr.h
@@ -115,7 +115,7 @@ public:
   }
 
   template <class Y>
-  shared_ptr<T> &operator=(const shared_ptr<Y, TM> &r){
+  shared_ptr &operator=(const shared_ptr<Y, TM> &r){
     shared_ptr s(r);
     swap(s);
     return *this;


### PR DESCRIPTION
Because the type of shared_ptr::operator ='s return value is wrong, two shared_ptrs which have different types for T and the same threading model other than the default type (pfi::concurrent::threading_model::single_thread) can't use their operator =.

``` example.cpp
shared_ptr<int, multi_thread> a;
shared_ptr<const int, multi_thread> b;
b = a; // compile error
```

This problem can be avoided by using its copy constructor.

``` workaround.cpp
shared_ptr<int, multi_thread> a;
shared_ptr<const int, multi_thread> c(a);
shared_ptr<const int, multi_thread> b;
b = c; // OK, because b and c have the same type for T (const int).
```
