### PR TITLE
Fixed wscript to support Mac OS

### DIFF
--- a/wscript
+++ b/wscript
@@ -8,6 +8,7 @@ import Options
 import sys
 import os
 import re
+import waflib
 
 subdirs = 'src tools'
 
@@ -83,16 +84,16 @@ def build(bld):
       ])
 
   bld.recurse(subdirs)
-  
-  ls = ''
+  libs = []
   for tasks in bld.get_build_iterator():
     if tasks == []:
       break
     for task in tasks:
-      for out in task.outputs:
-        o = str(out)
-        if re.match(r'libpficommon.*\.so$', o):
-          ls = ls + ' -l' + o[3:-3]
+      if isinstance(task.generator, waflib.TaskGen.task_gen) and 'cxxshlib' in task.generator.features:
+        libs.append(task.generator.target)
+  ls = ''
+  for l in set(libs):
+    ls = ls + ' -l' + l
 
   bld(source = 'pficommon.pc.in',
       prefix = bld.env['PREFIX'],


### PR DESCRIPTION
In Mac OS, extension of a shared library is ".dylib", but the current wscript assumes it ".so". So, Generated pficommon.pc cannot work in Mac environment.
I fixed wscript, and now it doesn't depend on any filename extensions.
