### PR TITLE
Added name space std:: to make_pair used in intern class.

### DIFF
--- a/src/data/intern.h
+++ b/src/data/intern.h
@@ -89,7 +89,7 @@ public:
     if (it!=tbl.end()) return it->second;
     if (gen==false) return -1;
     int id=tbl.size();
-    tbl.insert(make_pair(key,id));
+    tbl.insert(std::make_pair(key,id));
     lbt.push_back(key);
     return id;
   }


### PR DESCRIPTION
If template parameter _Key is not in std::, ADL doesn't work.
