### PR TITLE
fix inconsistent state of a filename change.

### DIFF
--- a/src/text/wscript
+++ b/src/text/wscript
@@ -21,7 +21,7 @@ def build(bld):
   
   bld.program(
     features = 'gtest',
-    source = 'json_test.cpp json_test_empty.cpp',
+    source = 'json_test.cpp json_multiple_definition_test.cpp',
     target = 'json_test',
     includes = '. json',
     use = 'pficommon_text')


### PR DESCRIPTION
My previous pull request (#53) was not perfect because I've forgotten to change a filename in wscript. This commit fix the problem.

Thanks @kuenishi for teaching this problem.
