### PR TITLE
Fix: dependent name must be referred with explicit "this->"

### DIFF
--- a/src/network/http/stream.h
+++ b/src/network/http/stream.h
@@ -99,7 +99,7 @@ class basic_httpstream : public std::basic_istream<C,T>{
 public:
   basic_httpstream(const std::string &url)
     : buf(url){
-    init(&buf);
+    this->init(&buf);
   }
   ~basic_httpstream(){
   }


### PR DESCRIPTION
This caused a compilation error on using httpstream.
