### PR TITLE
Fix issue #64: Cannot check write failure in mprpc library

### DIFF
--- a/src/network/mprpc/message.h
+++ b/src/network/mprpc/message.h
@@ -92,7 +92,7 @@ struct rpc_request {
   {
     msgpack::type::tuple<uint8_t, uint32_t, const std::string&, const P&>
       req(0, msgid, name, param);
-    return o.write(req, timeout_sec);
+    return o.write(req, timeout_sec) > 0;
   }
 
   template <typename T>
@@ -133,7 +133,7 @@ struct rpc_response {
   {
     msgpack::type::tuple<uint8_t, uint32_t, const E&, const R&>
       res(1, msgid, error, retval);
-    return o.write(res, timeout_sec);
+    return o.write(res, timeout_sec) > 0;
   }
 
   bool is_error() const


### PR DESCRIPTION
this code fixes issue #63

``` c++
  template <typename ObjectWritable, typename P>
  static bool write(ObjectWritable& o, uint32_t msgid, const std::string& name, const P& param, double timeout_sec)
  {
    msgpack::type::tuple<uint8_t, uint32_t, const std::string&, const P&>
      req(0, msgid, name, param);
    return o.write(req, timeout_sec) > 0; // <- Fixed HERE
  }
```

This original code assumes, ObjectWritable::write returns negative or positive `int`. So, I want to remove `typename ObjectWritable`, replace `ObjectWritable` to `object_stream` and change `object_stream::write(non-template function)` to private function but I don't. That can break compatibility.
