### PR TITLE
remove install_files line for pficommon.pc (fix #58)

### DIFF
--- a/wscript
+++ b/wscript
@@ -103,5 +103,3 @@ def build(bld):
       includedir = '${prefix}/include',
       PACKAGE = APPNAME,
       VERSION = VERSION)
-
-  bld.install_files(os.path.join(bld.env['LIBDIR'], 'pkgconfig'), 'pficommon.pc')


### PR DESCRIPTION
You don't have to write the `install_files` line for pkgconfig metadata (`*.pc`) in wscript, as waf automatically detects and installs it. Current wscript copies `pficommon.pc` twice to the same location and this operation conflicts sometimes. This fixes #58.

In my environment, only 822/1000 passed the install. After applying this patch, 1000/1000 passed the install.
