### PR TITLE
Replaced shared_ptr parameter types with "const shared_ptr&."

### DIFF
--- a/src/concurrent/chan.h
+++ b/src/concurrent/chan.h
@@ -106,7 +106,7 @@ private:
     r_mutex m;
   };
 
-  chan(pfi::lang::shared_ptr<link> l)
+  chan(const pfi::lang::shared_ptr<link>& l)
     :chans(l){
     synchronized(chans->m){
       chans->cs.insert(this);

--- a/src/data/serialization/map.h
+++ b/src/data/serialization/map.h
@@ -67,8 +67,8 @@ void serialize(Archive &ar, std::map<K, V, Compare, Allocator> &m)
 
 class map_type : public type_rep {
 public:
-  map_type(pfi::lang::shared_ptr<type_rep> key_type,
-           pfi::lang::shared_ptr<type_rep> value_type)
+  map_type(const pfi::lang::shared_ptr<type_rep>& key_type,
+           const pfi::lang::shared_ptr<type_rep>& value_type)
     : key_type_(key_type)
     , value_type_(value_type){
   }

--- a/src/data/serialization/reflect.h
+++ b/src/data/serialization/reflect.h
@@ -113,7 +113,7 @@ public:
     this->name=name;
   }
 
-  void add(const std::string &name, pfi::lang::shared_ptr<type_rep> type){
+  void add(const std::string &name, const pfi::lang::shared_ptr<type_rep>& type){
     member.push_back(make_pair(name, type));
   }
 

--- a/src/data/serialization/vector.h
+++ b/src/data/serialization/vector.h
@@ -53,7 +53,7 @@ void serialize(Archive &ar, std::vector<T, Allocator> &v)
 
 class array_type : public type_rep {
 public:
-  array_type(pfi::lang::shared_ptr<type_rep> type): type(type){}
+  array_type(const pfi::lang::shared_ptr<type_rep>& type): type(type){}
 
   void traverse(pfi::lang::function<void(type_rep*)> f){
     f(this);

--- a/src/database/mysql/value.cpp
+++ b/src/database/mysql/value.cpp
@@ -95,7 +95,7 @@ pfi::lang::shared_ptr<sql_value> from_bind(MYSQL_BIND &bind)
   return pfi::lang::shared_ptr<sql_value>(p);
 }
 
-size_t bind_length(pfi::lang::shared_ptr<sql_value> p)
+size_t bind_length(const pfi::lang::shared_ptr<sql_value>& p)
 {
   if (!p) return 0;
 
@@ -119,7 +119,7 @@ size_t bind_length(pfi::lang::shared_ptr<sql_value> p)
   }
 }
 
-void to_bind(pfi::lang::shared_ptr<sql_value> p, MYSQL_BIND &bind)
+void to_bind(const pfi::lang::shared_ptr<sql_value>& p, MYSQL_BIND &bind)
 {
   if (!p){
     bind.is_null=NULL;

--- a/src/database/mysql/value.h
+++ b/src/database/mysql/value.h
@@ -44,9 +44,9 @@ namespace pfi{
 namespace database{
 namespace mysql{
 
-size_t bind_length(pfi::lang::shared_ptr<sql_value> p);
+size_t bind_length(const pfi::lang::shared_ptr<sql_value>& p);
 pfi::lang::shared_ptr<sql_value> from_bind(MYSQL_BIND &bind);
-void to_bind(pfi::lang::shared_ptr<sql_value> p, MYSQL_BIND &bind);
+void to_bind(const pfi::lang::shared_ptr<sql_value>& p, MYSQL_BIND &bind);
 
 } // postgresql
 } // database

--- a/src/database/postgresql/statement.cpp
+++ b/src/database/postgresql/statement.cpp
@@ -58,7 +58,7 @@ static string convert_query(const string &q)
   return oss.str();
 }
 
-postgresql_statement::postgresql_statement(shared_ptr<postgresql_connection_impl> conn,
+postgresql_statement::postgresql_statement(const pfi::lang::shared_ptr<postgresql_connection_impl>& conn,
                                            const string &query)
   : conn(conn)
 {

--- a/src/database/postgresql/statement.h
+++ b/src/database/postgresql/statement.h
@@ -47,7 +47,7 @@ class postgresql_connection_impl;
 
 class postgresql_statement : public statement{
 public:
-  postgresql_statement(pfi::lang::shared_ptr<postgresql_connection_impl> conn,
+  postgresql_statement(const pfi::lang::shared_ptr<postgresql_connection_impl>& conn,
                        const std::string &query);
   ~postgresql_statement();
 

--- a/src/database/postgresql/value.cpp
+++ b/src/database/postgresql/value.cpp
@@ -122,7 +122,7 @@ shared_ptr<sql_value> str_to_sql(char *p, int len, int is_null, Oid oid)
   return shared_ptr<sql_value>(make_sql_value(p, len, t));
 }
 
-shared_ptr<string> sql_to_str(shared_ptr<sql_value> p)
+shared_ptr<string> sql_to_str(const pfi::lang::shared_ptr<sql_value>& p)
 {
   if (!p) return shared_ptr<string>();
 

--- a/src/database/postgresql/value.h
+++ b/src/database/postgresql/value.h
@@ -43,7 +43,7 @@ namespace postgresql{
 
 pfi::lang::shared_ptr<sql_value> str_to_sql(char *p, int len, int is_null, Oid oid);
 
-pfi::lang::shared_ptr<std::string> sql_to_str(pfi::lang::shared_ptr<sql_value> p);
+pfi::lang::shared_ptr<std::string> sql_to_str(const pfi::lang::shared_ptr<sql_value>& p);
 
 } // postgresql
 } // database

--- a/src/database/type.h
+++ b/src/database/type.h
@@ -168,10 +168,10 @@ inline pfi::lang::shared_ptr<sql_value> to_sql(const pfi::system::time::calendar
 }
 
 template <class T>
-T from_sql(pfi::lang::shared_ptr<sql_value> v);
+T from_sql(const pfi::lang::shared_ptr<sql_value>& v);
 
 template <>
-inline bool from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline bool from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   sql_bool *p=dynamic_cast<sql_bool*>(v.get());
   if (!p) throw database_error("from_sql: cannot convert to bool");
@@ -179,7 +179,7 @@ inline bool from_sql(pfi::lang::shared_ptr<sql_value> v)
 }
 
 template <>
-inline std::string from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline std::string from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   sql_string *p=dynamic_cast<sql_string*>(v.get());
   if (!p) return "";
@@ -187,7 +187,7 @@ inline std::string from_sql(pfi::lang::shared_ptr<sql_value> v)
 }
 
 template <>
-inline int32_t from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline int32_t from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   {
     sql_int32 *p=dynamic_cast<sql_int32*>(v.get());
@@ -210,7 +210,7 @@ inline int32_t from_sql(pfi::lang::shared_ptr<sql_value> v)
 }
 
 template <>
-inline int64_t from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline int64_t from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   {
     sql_int64 *p=dynamic_cast<sql_int64*>(v.get());
@@ -226,7 +226,7 @@ inline int64_t from_sql(pfi::lang::shared_ptr<sql_value> v)
 }
 
 template <>
-inline double from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline double from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   sql_float *p=dynamic_cast<sql_float*>(v.get());
   if (!p) throw database_error("from_sql: cannot convert to float");
@@ -234,7 +234,7 @@ inline double from_sql(pfi::lang::shared_ptr<sql_value> v)
 }
 
 template <>
-inline pfi::system::time::clock_time from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline pfi::system::time::clock_time from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   sql_timestamp *p=dynamic_cast<sql_timestamp*>(v.get());
   if (!p) throw database_error("from_sql: cannot convert to clock_time");
@@ -242,7 +242,7 @@ inline pfi::system::time::clock_time from_sql(pfi::lang::shared_ptr<sql_value> v
 }
 
 template <>
-inline pfi::system::time::calendar_time from_sql(pfi::lang::shared_ptr<sql_value> v)
+inline pfi::system::time::calendar_time from_sql(const pfi::lang::shared_ptr<sql_value>& v)
 {
   sql_timestamp *p=dynamic_cast<sql_timestamp*>(v.get());
   if (!p) throw database_error("from_sql: cannot convert to clock_time");

--- a/src/network/http/base.cpp
+++ b/src/network/http/base.cpp
@@ -125,7 +125,7 @@ static bool socket_getline(stream_socket *sock, string *str, int line_limit)
   return sock->getline(*str, line_limit);
 }
 
-header::header(pfi::lang::shared_ptr<stream_socket> sock)
+header::header(const pfi::lang::shared_ptr<stream_socket>& sock)
 {
   read_header(bind(&socket_getline, sock.get(), _1, line_limit));
 }
@@ -212,7 +212,7 @@ header::const_iterator header::end() const
   return dat.end();
 }
 
-void header::send(pfi::lang::shared_ptr<stream_socket> sock)
+void header::send(const pfi::lang::shared_ptr<stream_socket>& sock)
 {
   for (int i=0;i<(int)dat.size();i++){
     string line=dat[i].first+": "+dat[i].second+"\r\n";
@@ -229,7 +229,7 @@ class basic_httpbody_chunked_streambuf : public basic_streambuf<C,T>{
 public:
   typedef C char_type;
 
-  basic_httpbody_chunked_streambuf(pfi::lang::shared_ptr<stream_socket> sock)
+  basic_httpbody_chunked_streambuf(const pfi::lang::shared_ptr<stream_socket>& sock)
     : sock(sock)
     , chunk_rest(0)
     , buf(buf_size)
@@ -335,7 +335,7 @@ class basic_httpbody_streambuf : public basic_streambuf<C,T>{
 public:
   typedef C char_type;
 
-  basic_httpbody_streambuf(pfi::lang::shared_ptr<stream_socket> sock, int64_t length)
+  basic_httpbody_streambuf(const pfi::lang::shared_ptr<stream_socket>& sock, int64_t length)
     : sock(sock)
     , rest(length)
     , buf(T::eof()){
@@ -369,7 +369,7 @@ private:
 template <class C, class T=char_traits<C> >
 class basic_httpbody_chunked_stream : public basic_iostream<C,T>{
 public:
-  basic_httpbody_chunked_stream(pfi::lang::shared_ptr<stream_socket> sock)
+  basic_httpbody_chunked_stream(const pfi::lang::shared_ptr<stream_socket>& sock)
     : basic_iostream<C,T>()
     , buf(sock){
     this->init(&buf);
@@ -381,7 +381,7 @@ private:
 template <class C, class T=char_traits<C> >
 class basic_httpbody_stream : public basic_iostream<C,T>{
 public:
-  basic_httpbody_stream(pfi::lang::shared_ptr<stream_socket> sock, int64_t len)
+  basic_httpbody_stream(const pfi::lang::shared_ptr<stream_socket>& sock, int64_t len)
     : basic_iostream<C,T>()
     , buf(sock, len){
     this->init(&buf);
@@ -407,7 +407,7 @@ request::request(const string &method, const uri &u, int major_ver, int minor_ve
 {
 }
 
-request::request(pfi::lang::shared_ptr<stream_socket> sock)
+request::request(const pfi::lang::shared_ptr<stream_socket>& sock)
   : method_("")
   , uri_("/")
   , version_(1,1)
@@ -475,7 +475,7 @@ iostream &request::body()
   return *stream;
 }
 
-void request::send(pfi::lang::shared_ptr<stream_socket> sock)
+void request::send(const pfi::lang::shared_ptr<stream_socket>& sock)
 {
   stringstream *ss=dynamic_cast<stringstream*>(stream.get());
   if (!ss) throw http_exception("body is not stringstream");
@@ -519,7 +519,7 @@ response::response(int code, const string &reason, int major_ver, int minor_ver)
 {
 }
 
-response::response(pfi::lang::shared_ptr<stream_socket> sock)
+response::response(const pfi::lang::shared_ptr<stream_socket>& sock)
 {
   // status-line
   {
@@ -583,7 +583,7 @@ iostream &response::body()
   return *stream;
 }
 
-void response::send(pfi::lang::shared_ptr<stream_socket> sock)
+void response::send(const pfi::lang::shared_ptr<stream_socket>& sock)
 {
   stringstream *ss=dynamic_cast<stringstream*>(stream.get());
   if (!ss) throw http_exception("body is not stringstream");

--- a/src/network/http/base.h
+++ b/src/network/http/base.h
@@ -59,7 +59,7 @@ public:
   typedef dat_type::const_iterator const_iterator;
 
   header();
-  header(pfi::lang::shared_ptr<stream_socket> sock);
+  header(const pfi::lang::shared_ptr<stream_socket>& sock);
   header(std::istream &is);
 
   ~header();
@@ -79,7 +79,7 @@ public:
   iterator end();
   const_iterator end() const;
 
-  void send(pfi::lang::shared_ptr<stream_socket> sock);
+  void send(const pfi::lang::shared_ptr<stream_socket>& sock);
 
 private:
   void read_header(pfi::lang::function<bool(std::string*)> f);
@@ -102,7 +102,7 @@ public:
 class request{
 public:
   request(const std::string &method, const uri &u, int major_ver = 1, int minor_ver = 1);
-  request(pfi::lang::shared_ptr<stream_socket> sock);
+  request(const pfi::lang::shared_ptr<stream_socket>& sock);
 
   ~request();
 
@@ -115,7 +115,7 @@ public:
 
   // Send a request to socket
   // Don't call this method twice to same object.
-  void send(pfi::lang::shared_ptr<stream_socket> sock);
+  void send(const pfi::lang::shared_ptr<stream_socket>& sock);
 
 private:
   std::string method_;
@@ -130,7 +130,7 @@ class response{
 public:
   response();
   response(int code, const std::string &reason, int major_ver = 1, int minor_ver = 1);
-  response(pfi::lang::shared_ptr<stream_socket> sock);
+  response(const pfi::lang::shared_ptr<stream_socket>& sock);
 
   ~response();
 
@@ -143,7 +143,7 @@ public:
 
   // Send a response to socket
   // Don't call this method twice to same object.
-  void send(pfi::lang::shared_ptr<stream_socket> sock);
+  void send(const pfi::lang::shared_ptr<stream_socket>& sock);
 
 private:
   std::pair<int,int> version_;

--- a/src/network/mprpc/invoker.h
+++ b/src/network/mprpc/invoker.h
@@ -46,7 +46,7 @@ namespace mprpc {
 
 class responder {
 public:
-  responder(uint32_t msgid, pfi::lang::shared_ptr<rpc_stream> rs) :
+  responder(uint32_t msgid, const pfi::lang::shared_ptr<rpc_stream>& rs) :
     msgid(msgid), rs(rs) { }
 
 public:

--- a/src/network/mprpc/rpc_server.cpp
+++ b/src/network/mprpc/rpc_server.cpp
@@ -151,12 +151,12 @@ void rpc_server::process()
 }
 
 void rpc_server::add(const std::string &name,
-    pfi::lang::shared_ptr<invoker_base> invoker)
+                     const pfi::lang::shared_ptr<invoker_base>& invoker)
 {
   funcs[name] = invoker;
 }
 
-void rpc_server::process_request(rpc_request& req, pfi::lang::shared_ptr<rpc_stream> rs)
+void rpc_server::process_request(rpc_request& req, const pfi::lang::shared_ptr<rpc_stream>& rs)
 {
   responder res(req.msgid, rs);
 

--- a/src/network/mprpc/rpc_server.h
+++ b/src/network/mprpc/rpc_server.h
@@ -79,9 +79,9 @@ private:
   volatile bool serv_running;
 
   void add(const std::string &name,
-      pfi::lang::shared_ptr<invoker_base> invoker);
+           const pfi::lang::shared_ptr<invoker_base>& invoker);
 
-  void process_request(rpc_request& req, pfi::lang::shared_ptr<rpc_stream> rs);
+  void process_request(rpc_request& req, const pfi::lang::shared_ptr<rpc_stream>& rs);
 
   std::map<std::string, pfi::lang::shared_ptr<invoker_base> > funcs;
 };

--- a/src/network/rpc/base.cpp
+++ b/src/network/rpc/base.cpp
@@ -59,7 +59,7 @@ rpc_server::~rpc_server()
 {
 }
 
-void rpc_server::add(const string &name, pfi::lang::shared_ptr<invoker_base> invoker)
+void rpc_server::add(const string &name, const pfi::lang::shared_ptr<invoker_base>& invoker)
 {
   funcs[name]=invoker;
 }
@@ -80,7 +80,7 @@ bool rpc_server::serv(uint16_t port, int nthreads)
   return true;
 }
 
-void rpc_server::process(pfi::lang::shared_ptr<server_socket> ssock)
+void rpc_server::process(const pfi::lang::shared_ptr<server_socket>& ssock)
 {
   for (;;){
     pfi::lang::shared_ptr<stream_socket> sock(ssock->accept());
@@ -178,7 +178,7 @@ pfi::lang::shared_ptr<socketstream> rpc_client::get_connection()
   return ss;
 }
 
-void rpc_client::return_connection(pfi::lang::shared_ptr<socketstream> css)
+void rpc_client::return_connection(const shared_ptr<socketstream>& css)
 {
   ss=css;
 }

--- a/src/network/rpc/base.h
+++ b/src/network/rpc/base.h
@@ -68,9 +68,9 @@ public:
 
 private:
   void add(const std::string &name,
-      pfi::lang::shared_ptr<invoker_base> invoker);
+           const pfi::lang::shared_ptr<invoker_base>& invoker);
 
-  void process(pfi::lang::shared_ptr<server_socket> sock);
+  void process(const pfi::lang::shared_ptr<server_socket>& sock);
 
   std::map<std::string, pfi::lang::shared_ptr<invoker_base> > funcs;
 
@@ -92,7 +92,7 @@ public:
 
 private:
   pfi::lang::shared_ptr<socketstream> get_connection();
-  void return_connection(pfi::lang::shared_ptr<socketstream> css);
+  void return_connection(const pfi::lang::shared_ptr<socketstream>& css);
 
   int get_version();
 

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -88,7 +88,7 @@ stream_socket::~stream_socket()
   close();
 }
 
-void stream_socket::set_dns_resolver(pfi::lang::shared_ptr<dns_resolver> r)
+void stream_socket::set_dns_resolver(const shared_ptr<dns_resolver>& r)
 {
   synchronized(resolver_m)
     resolver=r;

--- a/src/network/socket.h
+++ b/src/network/socket.h
@@ -82,7 +82,7 @@ public:
   // bool set_...
 
   static void set_dns_resolver
-  (pfi::lang::shared_ptr<dns_resolver> resolver);
+  (const pfi::lang::shared_ptr<dns_resolver>& resolver);
 
 private:
   bool open();

--- a/src/text/xhtml.h
+++ b/src/text/xhtml.h
@@ -68,7 +68,7 @@ public:
     return attr_[key];
   }
 
-  void add_child(pfi::lang::shared_ptr<html_elem> elem){
+  void add_child(const pfi::lang::shared_ptr<html_elem>& elem){
     children_.push_back(elem);
   }
 


### PR DESCRIPTION
Copying shared_ptr has overhead, so replaced shared_ptr with "const shared_ptr&" in function parameter type.
