### PR TITLE
Use strtod/strtoll for parsing numbers in json parser class.

### DIFF
--- a/src/text/json_test.cpp
+++ b/src/text/json_test.cpp
@@ -722,6 +722,16 @@ TEST(json, parse)
   }
 }
 
+TEST(json, bignum_parse)
+{
+  {
+    // 36893488147419103233 == 2^65 + 1
+    istringstream iss("36893488147419103233e0");
+    json j;iss>>j;
+    EXPECT_DOUBLE_EQ(36893488147419103233e0, json_cast<double>(j));
+  }
+}
+
 TEST(json, pretty)
 {
   {


### PR DESCRIPTION
Current implementation fails to parse in some corner case like parsing very big number.
This pull request use strtod/strtoll for pasing numbers. (This req also add a test case for parsing 2^65).
