### PR TITLE
Enable pfi::network::uri to parse an IPv6 address.

### DIFF
--- a/src/network/uri.cpp
+++ b/src/network/uri.cpp
@@ -566,9 +566,9 @@ bool uri::parse_ipv6_9(const char *&p)
 bool uri::parse_h16(const char *&p)
 {
   if (!isxdigit(*p++)) return false;
-  if (!isxdigit(*p)) p++;
-  if (!isxdigit(*p)) p++;
-  if (!isxdigit(*p)) p++;
+  if (!isxdigit(*p++)) return false; 
+  if (!isxdigit(*p++)) return false;
+  if (!isxdigit(*p++)) return false;
   return true;
 }
 

--- a/src/network/uri_test.cpp
+++ b/src/network/uri_test.cpp
@@ -126,6 +126,10 @@ TEST(uri, class)
   EXPECT_EQ("/aoeu/htns", complex.path());
   EXPECT_EQ("q=1234&r=5678", complex.query());
   EXPECT_EQ("n42", complex.fragment());
+
+  uri ipv6("http://[2001:0DB8:0000:CD30:0123:4567:89AB:CDEF]/");
+  EXPECT_EQ("http", ipv6.scheme());
+  EXPECT_EQ("[2001:0DB8:0000:CD30:0123:4567:89AB:CDEF]", ipv6.host());
 }
 
 TEST(uri, authority)


### PR DESCRIPTION
This patch enables pfi::network::uri to parse an IPv6 address
though we can't compress zero bits in an IPv6 address for now.
