### PR TITLE
Avoid dangling else

### DIFF
--- a/src/text/json/parser.h
+++ b/src/text/json/parser.h
@@ -96,11 +96,12 @@ private:
   }
 
   int peek() {
-    if (cbuf < 0)
+    if (cbuf < 0) {
       if (it != end)
         cbuf = pfi::data::string::chars_to_uchar(it, end);
       else
         throw pfi::lang::end_of_data("json_parser reached end of data");
+    }
     return cbuf;
   }
   int incr() {


### PR DESCRIPTION
put brace in if statement is good way to avoid ambiguity.
