### PR TITLE
Comment out unused parameters

### DIFF
--- a/src/data/serialization/iostream.h
+++ b/src/data/serialization/iostream.h
@@ -156,7 +156,7 @@ public:
 };
 
 template <class Func>
-void serialize(reflection &ref, stream<Func> &str)
+void serialize(reflection &ref, stream<Func> & /*str*/)
 {
   ref.add("", pfi::lang::shared_ptr<type_rep>(new stream_type()));
 }

--- a/src/data/serialization/reflect.h
+++ b/src/data/serialization/reflect.h
@@ -286,7 +286,7 @@ public:
 };
 
 template <class Ar>
-inline void serialize(Ar &ar, class_name &)
+inline void serialize(Ar &/*ar*/, class_name &)
 {
 }
 

--- a/src/text/json/base.h
+++ b/src/text/json/base.h
@@ -759,14 +759,14 @@ inline void gen_print(std::ostream& os, const T& js, bool pretty, bool escape)
 }
 
 template <class T>
-inline void gen_print(std::ostream& os, const pretty_tag<T>& js, bool pretty, bool escape)
+inline void gen_print(std::ostream& os, const pretty_tag<T>& js, bool /*pretty*/, bool escape)
 {
   gen_print(os, js.dat, true, escape);
 }
 
 
 template <class T>
-inline void gen_print(std::ostream& os, const without_escape_tag<T>& js, bool pretty, bool escape)
+inline void gen_print(std::ostream& os, const without_escape_tag<T>& js, bool pretty, bool /*escape*/)
 {
   gen_print(os, js.dat, pretty, false);
 }


### PR DESCRIPTION
I commented out unused parameters to suppress warnings with clang.
