### PR TITLE
Fix jsoncast namedvalue

### DIFF
--- a/src/text/json/cast.h
+++ b/src/text/json/cast.h
@@ -529,12 +529,21 @@ inline void serialize(json_iarchive_cast_with_default& js, std::vector<T>& v)
 }
 
 template <class T>
+inline void serialize(json_iarchive_cast& js, pfi::data::serialization::named_value<pfi::data::optional<T> >& v)
+{
+  if (js.get().count(v.name))
+    from_json(js.get()[v.name], v.v);
+  else
+    v.v = pfi::data::optional<T>();
+}
+
+template <class T>
 inline void serialize(json_iarchive_cast& js, pfi::data::serialization::named_value<T>& v)
 {
   if (js.get().count(v.name))
     from_json(js.get()[v.name], v.v);
   else
-    from_json(json(), v.v);
+    throw json_bad_cast<pfi::data::serialization::named_value<T> >("\"" + v.name + "\" is not found.");
 }
 
 template <class T>

--- a/src/text/json_test.cpp
+++ b/src/text/json_test.cpp
@@ -1221,3 +1221,13 @@ TEST(json, finite)
       json j(new json_float(0.0 / 0.0)),
       json_bad_cast<json_float>);
 }
+
+TEST(json, not_found_member)
+{
+  json js(new json_object);
+  try {
+    opt1 s = json_cast<opt1>(js);
+    FAIL();
+  } catch(const json_bad_cast<named_value<int> >& e) {
+  }
+}

--- a/src/text/json_test.cpp
+++ b/src/text/json_test.cpp
@@ -1222,6 +1222,32 @@ TEST(json, finite)
       json_bad_cast<json_float>);
 }
 
+TEST(json, named_optional_value) {
+  pfi::data::optional<int> n;
+  named_value<pfi::data::optional<int> > value("num", n);
+
+  json js(new json_object);
+  js["num"] = to_json(10);
+
+  from_json(js, value);
+
+  EXPECT_TRUE(n);
+  EXPECT_EQ(10, *n);
+}
+
+TEST(json, named_optional_value_null) {
+  pfi::data::optional<int> n;
+  n = 1;
+  named_value<pfi::data::optional<int> > value("num", n);
+
+  json js(new json_object);
+
+  from_json(js, value);
+
+  // n is removed
+  EXPECT_FALSE(n);
+}
+
 TEST(json, not_found_member)
 {
   json js(new json_object);

--- a/src/text/json_test.cpp
+++ b/src/text/json_test.cpp
@@ -1225,9 +1225,5 @@ TEST(json, finite)
 TEST(json, not_found_member)
 {
   json js(new json_object);
-  try {
-    opt1 s = json_cast<opt1>(js);
-    FAIL();
-  } catch(const json_bad_cast<named_value<int> >& e) {
-  }
+  EXPECT_THROW(opt1 s = json_cast<opt1>(js), json_bad_cast<named_value<int> >);
 }


### PR DESCRIPTION
I fixed cast method for `named_value<optional<T> >`. The original implementation throws an exception with a unreadable message when an expected parameter is not found.
I add a specialized function for `named_value<optional<T> >` that checks a given parameter and throws an exception with a readable error message if it is not found. 