### PR TITLE
fix src/database/wscript to check PGSQL rightly

### DIFF
--- a/src/database/postgresql/value.cpp
+++ b/src/database/postgresql/value.cpp
@@ -34,6 +34,7 @@
 #include <iomanip>
 #include <iostream>
 #include <cstring>
+#include <cstdlib>
 
 #include "types.h"
 #include "../../lang/cast.h"

--- a/src/database/wscript
+++ b/src/database/wscript
@@ -23,11 +23,11 @@ def configure(conf):
   conf.env.BUILD_PGSQL = False
   if not Options.options.disable_database:
     try:
-      incdir = subprocess.check_output(['pg_config', '--includedir-server']).decode()
-      libdir = subprocess.check_output(['pg_config', '--libdir']).decode()
+      incdir = subprocess.check_output(['pg_config', '--includedir-server']).decode().rstrip()
+      libdir = subprocess.check_output(['pg_config', '--libdir']).decode().rstrip()
       if conf.check_cxx(lib = 'pq',
                         header_name = 'postgres.h',
-                        cxxflags = '-I' + incdir,
+                        cxxflags = [ '-I' + incdir ],
                         libpath = libdir,
                         uselib_store = 'PGSQL',
                         mandatory = False):


### PR DESCRIPTION
fix src/database/wscript

- result of `subprocess.check_output` should be r-stripped to remove trailing new line
- `cxxflags` should be array of string
 
```
[ '/usr/bin/g++'
, '-O2'
, '-Wall'
, '-g'
, '-pipe'
, '-D_REENTRANT'
, '-fno-omit-frame-pointer'
, '-D_FORTIFY_SOURCE=1'
, u'-', u'I', u'/', u'u', u's', u'r', u'i', u'n', u'c', u'l', u'd', u'e', u'p', u'o', u't', u'g', u'q', u'v'
, '-DHAVE_MSGPACK_HPP=1'
, '-DHAVE_STDINT_H=1'
, '-DHAVE_TR1_UNORDERED_MAP=1'
, '-DHAVE_EXT_HASH_MAP=1'
, '-DHAVE_TR1_UNORDERED_SET=1'
, '-DHAVE_EXT_HASH_SET=1'
, '../test.cpp', '-c', '-o', 'test.cpp.1.o']
```