### PR TITLE
pfi::data::string::chars_to_uchar handle invalid utf-8 strictly

### DIFF
--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -91,7 +91,7 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end)
   // But it could only be used for an overlong encoding of ASCII characters,
   // so it will be checked together after.
   if (c < 0xC0 || c > 0xFD) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 single byte character is out of range. "
+    throw std::invalid_argument("Invalid UTF-8: UTF-8 first byte of character is out of range. "
 				"It must not be in range of [0x80, 0xBF] or [0xFE, 0xFF]");
   }
 
@@ -109,7 +109,7 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end)
       break;
     }
 
-  // There is no problem by using (nbytes == 2).
+  // There is no problem by using (nbytes == 0).
   // But nbytes(>= 2) is used later, so (nbytes < 2) is used here for readability.
   if (nbytes < 2) {
     throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences have a 5-byte or 6-byte sequence");

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -1,0 +1,174 @@
+// Copyright (c)2008-2011, Preferred Infrastructure Inc.
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+// 
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+// 
+//     * Neither the name of Preferred Infrastructure nor the names of other
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "./ustring.h"
+
+using namespace pfi::data::string;
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_are_empty)
+{  const char* p="";
+  EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument);
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)
+{
+  for (int c = 0x80; c < 0xBF; c++) {
+    std::string str(1u, static_cast<char>(c));
+    const char* p=str.c_str();
+    EXPECT_THROW({chars_to_uchar(p, p + str.size());}, std::invalid_argument)
+      << std::hex << c;
+  }
+  for (int c = 0xFE; c <= 0xFF; c++) {
+    std::string str(1u, static_cast<char>(c));
+    const char* p=str.c_str();
+    EXPECT_THROW({chars_to_uchar(p, p + str.size());}, std::invalid_argument)
+      << std::hex << c;
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_5_byte_sequence)
+{
+  { // min 5-byte sequence
+    const char str[] = {0xF8, 0x80, 0x80, 0x80, 0x80, 0x00};
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+  { // max 5-byte sequence
+    const char str[] = {0xFB, 0xBF, 0xBF, 0xBF, 0xBF, 0x00};
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
+{
+  { // min 6-byte sequence
+    const char str[] = {0xFC, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00};
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+  { // max 6-byte sequence
+    const char str[] = {0xFD, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF, 0x00};
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_end_with_imcomplete_byte_sequence)
+{
+  {
+    const char str[] = {0xE3, 0x00}; // 2 bytes are missing
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+  {
+    const char str[] = {0xE3, 0x80, 0x00}; // 1 byte is missing
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_start_byte_not_enough_continuation_bytes)
+{
+  {
+    const char str[] = {0xE3, 0x80, // 1 byte is missing here
+                        0xE3, 0x80, 0x81, 0x00};
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
+{
+  { // Example of an overlong ASCII character('/')
+    const char str[3][5] = {
+      {0xC0, 0xAF, 0x00},
+      {0xE0, 0x80, 0xAF, 0x00},
+      {0xF0, 0x80, 0x80, 0xAF, 0x00},
+    };
+    for (size_t i = 0; i < 3; i++) {
+      const char* p=str[i];
+      EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+    }
+  }
+  { // Maximum overlong sequences
+    const char str[3][5] = {
+      {0xC1, 0xBF, 0x00},
+      {0xE0, 0x9F, 0xBF, 0x00},
+      {0xF0, 0x8F, 0xBF, 0xBF, 0x00},
+    };
+    for (size_t i = 0; i < 3; i++) {
+      const char* p=str[i];
+      EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+    }
+  }
+  { // Minimum overlong sequences (NUL character)
+    const char str[3][5] = {
+      {0xC0, 0x80, 0x00},
+      {0xE0, 0x80, 0x80, 0x00},
+      {0xF0, 0x80, 0x80, 0x80, 0x00},
+    };
+    for (size_t i = 0; i < 3; i++) {
+      const char* p=str[i];
+      EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+    }
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_invalid_4_byte_sequence)
+{
+  {
+    const char str[] = {0xF4, 0x8F, 0x8F, 0x8F, 0x00}; // U+10FFFF
+    const char* p=str;
+    EXPECT_NO_THROW(chars_to_uchar(p, p + strlen(p))) << str;
+  }
+  {
+    const char str[] = {0xF4, 0x90, 0x80, 0x80, 0x00}; // U+110000
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+}
+
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_surrogate)
+{
+  {
+    const char str[] = {0xED, 0xA0, 0x80, 0x00}; // U+D800
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+  {
+    const char str[] = {0xED, 0xBF, 0xBF, 0x00}; // U+DFFF
+    const char* p=str;
+    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
+  }
+}

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -59,12 +59,12 @@ TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_5_byte_sequence)
 {
   { // min 5-byte sequence
-    const char str[] = {0xF8, 0x80, 0x80, 0x80, 0x80, 0x00};
+    const char str[] = {'\xF8', '\x80', '\x80', '\x80', '\x80', '\x00'};
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
   { // max 5-byte sequence
-    const char str[] = {0xFB, 0xBF, 0xBF, 0xBF, 0xBF, 0x00};
+    const char str[] = {'\xFB', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
@@ -73,12 +73,12 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_5_byte_sequence)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
 {
   { // min 6-byte sequence
-    const char str[] = {0xFC, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00};
+    const char str[] = {'\xFC', '\x80', '\x80', '\x80', '\x80', '\x00'};
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
   { // max 6-byte sequence
-    const char str[] = {0xFD, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF, 0x00};
+    const char str[] = {'\xFD', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
@@ -87,12 +87,12 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_end_with_imcomplete_byte_sequence)
 {
   {
-    const char str[] = {0xE3, 0x00}; // 2 bytes are missing
+    const char str[] = {'\xE3', '\x00'}; // 2 bytes are missing
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
   {
-    const char str[] = {0xE3, 0x80, 0x00}; // 1 byte is missing
+    const char str[] = {'\xE3', '\x80', '\x00'}; // 1 byte is missing
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
@@ -101,8 +101,8 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_end_with_imcomplete_byte_se
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_start_byte_not_enough_continuation_bytes)
 {
   {
-    const char str[] = {0xE3, 0x80, // 1 byte is missing here
-                        0xE3, 0x80, 0x81, 0x00};
+    const char str[] = {'\xE3', '\x80', // 1 byte is missing here
+                        '\xE3', '\x80', '\x81', '\x00'};
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
@@ -112,9 +112,9 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
 {
   { // Example of an overlong ASCII character('/')
     const char str[3][5] = {
-      {0xC0, 0xAF, 0x00},
-      {0xE0, 0x80, 0xAF, 0x00},
-      {0xF0, 0x80, 0x80, 0xAF, 0x00},
+      {'\xC0', '\xAF', '\x00'},
+      {'\xE0', '\x80', '\xAF', '\x00'},
+      {'\xF0', '\x80', '\x80', '\xAF', '\x00'},
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
@@ -123,9 +123,9 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
   }
   { // Maximum overlong sequences
     const char str[3][5] = {
-      {0xC1, 0xBF, 0x00},
-      {0xE0, 0x9F, 0xBF, 0x00},
-      {0xF0, 0x8F, 0xBF, 0xBF, 0x00},
+      {'\xC1', '\xBF', '\x00'},
+      {'\xE0', '\x9F', '\xBF', '\x00'},
+      {'\xF0', '\x8F', '\xBF', '\xBF', '\x00'},
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
@@ -134,9 +134,9 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
   }
   { // Minimum overlong sequences (NUL character)
     const char str[3][5] = {
-      {0xC0, 0x80, 0x00},
-      {0xE0, 0x80, 0x80, 0x00},
-      {0xF0, 0x80, 0x80, 0x80, 0x00},
+      {'\xC0', '\x80', '\x00'},
+      {'\xE0', '\x80', '\x80', '\x00'},
+      {'\xF0', '\x80', '\x80', '\x80', '\x00'},
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
@@ -148,12 +148,12 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_invalid_4_byte_sequence)
 {
   {
-    const char str[] = {0xF4, 0x8F, 0x8F, 0x8F, 0x00}; // U+10FFFF
+    const char str[] = {'\xF4', '\x8F', '\x8F', '\x8F', '\x00'}; // U+10FFFF
     const char* p=str;
     EXPECT_NO_THROW(chars_to_uchar(p, p + strlen(p))) << str;
   }
   {
-    const char str[] = {0xF4, 0x90, 0x80, 0x80, 0x00}; // U+110000
+    const char str[] = {'\xF4', '\x90', '\x80', '\x80', '\x00'}; // U+110000
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
@@ -162,12 +162,12 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_invalid_4_byte_sequ
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_surrogate)
 {
   {
-    const char str[] = {0xED, 0xA0, 0x80, 0x00}; // U+D800
+    const char str[] = {'\xED', '\xA0', '\x80', '\x00'}; // U+D800
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }
   {
-    const char str[] = {0xED, 0xBF, 0xBF, 0x00}; // U+DFFF
+    const char str[] = {'\xED', '\xBF', '\xBF', '\x00'}; // U+DFFF
     const char* p=str;
     EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument) << str;
   }

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -147,11 +147,11 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
         << FormatByteSequence(str[i]);
     }
   }
-  { // Maximum overlong sequences
+  { // Minimum overlong sequences (NUL character)
     const char str[3][5] = {
-      {'\xC1', '\xBF', '\x00'},
-      {'\xE0', '\x9F', '\xBF', '\x00'},
-      {'\xF0', '\x8F', '\xBF', '\xBF', '\x00'},
+      {'\xC0', '\x80', '\x00'},
+      {'\xE0', '\x80', '\x80', '\x00'},
+      {'\xF0', '\x80', '\x80', '\x80', '\x00'},
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
@@ -159,11 +159,11 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
         << FormatByteSequence(str[i]);
     }
   }
-  { // Minimum overlong sequences (NUL character)
+  { // Maximum overlong sequences
     const char str[3][5] = {
-      {'\xC0', '\x80', '\x00'},
-      {'\xE0', '\x80', '\x80', '\x00'},
-      {'\xF0', '\x80', '\x80', '\x80', '\x00'},
+      {'\xC1', '\xBF', '\x00'},
+      {'\xE0', '\x9F', '\xBF', '\x00'},
+      {'\xF0', '\x8F', '\xBF', '\xBF', '\x00'},
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];

--- a/src/data/wscript
+++ b/src/data/wscript
@@ -79,6 +79,7 @@ def build(bld):
   t('string/algorithm_test.cpp')
   t('string/aho_corasick_test.cpp')
   t('string/ustring_test.cpp')
+  t('string/ustring_utf_8_decode_test.cpp')
   t('string/utility_test.cpp')
   t('sparse_matrix/sparse_matrix_test.cpp')
   t('intern_test.cpp')


### PR DESCRIPTION
This PR change that pfi::data::string::chars_to_uchar strictly check invalid byte sequence.

* surrogate([U+D800, U+DFFF]) will be treated as invalid byte sequence
* 4-byte sequence more than U+10FFFF will be treated as invalid byte sequence

These changes affect following methods:

* pfi::data::string::chars_to_uchar
* pfi::data::string::string_to_ustring

And those exception messages become in detail.
