### PR TITLE
Support fallback for UTF-8 decoding

### DIFF
--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -122,7 +122,7 @@ template <class InputIterator1, class InputIterator2>
 uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
                           fallback_base& fb)
 {
-  InputIterator1 begin = in;
+  const InputIterator1 begin = in;
   if (in == end) {
     return fb.fallback(std::string(begin, in),
                        "Invalid UTF-8: UTF-8 byte sequences are empty");

--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -82,7 +82,7 @@ public:
   }
 
   virtual uchar fallback(const std::string& bytes,
-			 const char* hint) = 0;
+                         const char* hint) = 0;
 };
 
 class exception_fallback : public fallback_base {
@@ -91,7 +91,7 @@ public:
   }
 
   virtual uchar fallback(const std::string& bytes,
-			 const char* hint) {
+                         const char* hint) {
     throw std::invalid_argument(hint);
     return 0x0000;
   }
@@ -106,7 +106,7 @@ public:
   }
 
   virtual uchar fallback(const std::string& bytes,
-			 const char* hint) {
+                         const char* hint) {
     if (bytes.empty()) {
       return 0x0000;
     }
@@ -120,12 +120,12 @@ private:
 namespace detail {
 template <class InputIterator1, class InputIterator2>
 uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
-			  fallback_base& fb)
+                          fallback_base& fb)
 {
   InputIterator1 begin = in;
   if (in == end) {
     return fb.fallback(std::string(begin, in),
-		       "Invalid UTF-8: UTF-8 byte sequences are empty");
+                       "Invalid UTF-8: UTF-8 byte sequences are empty");
   }
 
   if (((*in) & 0x80) == 0) // U+0000 to U+007F
@@ -137,8 +137,8 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
   // so it will be checked together after.
   if (c < 0xC0 || c > 0xFD) {
     return fb.fallback(std::string(begin, in),
-		       "Invalid UTF-8: UTF-8 first byte of character is out of range. "
-		       "It must not be in range of [0x80, 0xBF] or [0xFE, 0xFF]");
+                       "Invalid UTF-8: UTF-8 first byte of character is out of range. "
+                       "It must not be in range of [0x80, 0xBF] or [0xFE, 0xFF]");
   }
 
   static const uchar head_masks[] = { 0xE0, 0xF0, 0xF8, 0xFC, 0xFE };
@@ -158,11 +158,11 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
   for (int i = 1; i < nbytes; ++i) {
     if (in == end) {
       return fb.fallback(std::string(begin, in),
-			 "Invalid UTF-8: UTF-8 byte sequences end with incomplete byte sequence");
+                         "Invalid UTF-8: UTF-8 byte sequences end with incomplete byte sequence");
     }
     if ((*in & 0xC0) != 0x80) {
       return fb.fallback(std::string(begin, in),
-			 "Invalid UTF-8: UTF-8 byte sequences have a start byte not followed by enough continuation bytes");
+                         "Invalid UTF-8: UTF-8 byte sequences have a start byte not followed by enough continuation bytes");
     }
     ret <<= 6;
     ret |= *in++ & 0x3F;
@@ -170,7 +170,7 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
 
   if (nbytes >= 5) {
     return fb.fallback(std::string(begin, in),
-		       "Invalid UTF-8: UTF-8 byte sequences have a 5-byte or 6-byte sequence");
+                       "Invalid UTF-8: UTF-8 byte sequences have a 5-byte or 6-byte sequence");
   }
 
   static const uchar mins[] = { 0, 0, 0x80, 0x800, 0x10000 };
@@ -178,19 +178,19 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
 
   if (ret < mins[nbytes] || ret > maxs[nbytes]) {
     return fb.fallback(std::string(begin, in),
-		       "Invalid UTF-8: UTF-8 byte sequences have an overlong encoding");
+                       "Invalid UTF-8: UTF-8 byte sequences have an overlong encoding");
   }
 
   if (ret > 0x10FFFF) {
     return fb.fallback(std::string(begin, in),
-		       "Invalid UTF-8: UTF-8 byte sequences have an invalid 4-byte sequence. "
-		       "It decodes to a value greater than U+10FFFF");
+                       "Invalid UTF-8: UTF-8 byte sequences have an invalid 4-byte sequence. "
+                       "It decodes to a value greater than U+10FFFF");
   }
 
   if (0xD800 <= ret && ret <= 0xDFFF) {
     return fb.fallback(std::string(begin, in),
-		       "Invalid UTF-8: UTF-8 byte sequences have a surrogate. "
-		       "It must not be in range of [0xD800, 0xDFFF]");
+                       "Invalid UTF-8: UTF-8 byte sequences have a surrogate. "
+                       "It must not be in range of [0xD800, 0xDFFF]");
   }
 
   return ret;

--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -92,6 +92,9 @@ public:
 
   virtual uchar fallback(const std::string& bytes,
                          const char* hint) {
+    if (bytes.empty()) {
+      return 0x0000;
+    }
     throw std::invalid_argument(hint);
     return 0x0000;
   }

--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -96,7 +96,6 @@ public:
       return 0x0000;
     }
     throw std::invalid_argument(hint);
-    return 0x0000;
   }
 };
 

--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -36,6 +36,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string>
+#include <algorithm>
 #include <stdint.h>
 #include <stdexcept>
 
@@ -75,24 +76,69 @@ uchar string_to_uchar(const char* p);
 uchar string_to_uchar(const std::string& s);
 std::string uchar_to_string(uchar uc);
 
+class fallback_base {
+public:
+  virtual ~fallback_base() {
+  }
+
+  virtual uchar fallback(const std::string& bytes,
+			 const char* hint) = 0;
+};
+
+class exception_fallback : public fallback_base {
+public:
+  virtual ~exception_fallback() {
+  }
+
+  virtual uchar fallback(const std::string& bytes,
+			 const char* hint) {
+    throw std::invalid_argument(hint);
+    return 0x0000;
+  }
+};
+
+class replacement_fallback : public fallback_base {
+public:
+  replacement_fallback(uchar replace) : replace(replace) {
+  }
+
+  virtual ~replacement_fallback() {
+  }
+
+  virtual uchar fallback(const std::string& bytes,
+			 const char* hint) {
+    if (bytes.empty()) {
+      return 0x0000;
+    }
+    return replace;
+  }
+
+private:
+  uchar replace;
+};
+
 namespace detail {
 template <class InputIterator1, class InputIterator2>
-uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end)
+uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end,
+			  fallback_base& fb)
 {
+  InputIterator1 begin = in;
   if (in == end) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences are empty");
+    return fb.fallback(std::string(begin, in),
+		       "Invalid UTF-8: UTF-8 byte sequences are empty");
   }
 
   if (((*in) & 0x80) == 0) // U+0000 to U+007F
     return *in++;
 
-  const unsigned c = *in & 0xFF;
+  const unsigned c = *in++ & 0xFF;
   // It is an invalid byte also when c is 0xC0 or 0xC1.
   // But it could only be used for an overlong encoding of ASCII characters,
   // so it will be checked together after.
   if (c < 0xC0 || c > 0xFD) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 first byte of character is out of range. "
-				"It must not be in range of [0x80, 0xBF] or [0xFE, 0xFF]");
+    return fb.fallback(std::string(begin, in),
+		       "Invalid UTF-8: UTF-8 first byte of character is out of range. "
+		       "It must not be in range of [0x80, 0xBF] or [0xFE, 0xFF]");
   }
 
   static const uchar head_masks[] = { 0xE0, 0xF0, 0xF8 };
@@ -103,8 +149,8 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end)
   int nbytes = 0;
 
   for (size_t i = 0; i < sizeof(head_masks)/sizeof(head_masks[0]); ++i)
-    if ((*in & head_masks[i]) == flag_bits[i]) {
-      ret = *in++ & tail_masks[i];
+    if ((c & head_masks[i]) == flag_bits[i]) {
+      ret = c & tail_masks[i];
       nbytes = i + 2;
       break;
     }
@@ -112,15 +158,18 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end)
   // There is no problem by using (nbytes == 0).
   // But nbytes(>= 2) is used later, so (nbytes < 2) is used here for readability.
   if (nbytes < 2) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences have a 5-byte or 6-byte sequence");
+    return fb.fallback(std::string(begin, in),
+		       "Invalid UTF-8: UTF-8 byte sequences have a 5-byte or 6-byte sequence");
   }
 
   for (int i = 1; i < nbytes; ++i) {
     if (in == end) {
-      throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences end with incomplete byte sequence");
+      return fb.fallback(std::string(begin, in),
+			 "Invalid UTF-8: UTF-8 byte sequences end with incomplete byte sequence");
     }
     if ((*in & 0xC0) != 0x80) {
-      throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences have a start byte not followed by enough continuation bytes");
+      return fb.fallback(std::string(begin, in),
+			 "Invalid UTF-8: UTF-8 byte sequences have a start byte not followed by enough continuation bytes");
     }
     ret <<= 6;
     ret |= *in++ & 0x3F;
@@ -130,17 +179,20 @@ uchar chars_to_uchar_impl(InputIterator1& in, InputIterator2 end)
   static const uchar maxs[] = { 0, 0, 0x7FF, 0xFFFF, 0x1FFFFF };
 
   if (ret < mins[nbytes] || ret > maxs[nbytes]) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences have an overlong encoding");
+    return fb.fallback(std::string(begin, in),
+		       "Invalid UTF-8: UTF-8 byte sequences have an overlong encoding");
   }
 
   if (ret > 0x10FFFF) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences have an invalid 4-byte sequence. "
-				"It decodes to a value greater than U+10FFFF");
+    return fb.fallback(std::string(begin, in),
+		       "Invalid UTF-8: UTF-8 byte sequences have an invalid 4-byte sequence. "
+		       "It decodes to a value greater than U+10FFFF");
   }
 
   if (0xD800 <= ret && ret <= 0xDFFF) {
-    throw std::invalid_argument("Invalid UTF-8: UTF-8 byte sequences have a surrogate. "
-				"It must not be in range of [0xD800, 0xDFFF]");
+    return fb.fallback(std::string(begin, in),
+		       "Invalid UTF-8: UTF-8 byte sequences have a surrogate. "
+		       "It must not be in range of [0xD800, 0xDFFF]");
   }
 
   return ret;
@@ -164,13 +216,21 @@ uchar chars_to_uchar(InputIterator&) __attribute__((deprecated));
 template <class InputIterator>
 uchar chars_to_uchar(InputIterator& in)
 {
-  return detail::chars_to_uchar_impl(in, detail::dummy_end_iterator());
+  replacement_fallback fb(0xFFFD);
+  return detail::chars_to_uchar_impl(in, detail::dummy_end_iterator(), fb);
 }
 
 template <class InputIterator>
 uchar chars_to_uchar(InputIterator& in, InputIterator end)
 {
-  return detail::chars_to_uchar_impl(in, end);
+  replacement_fallback fb(0xFFFD);
+  return detail::chars_to_uchar_impl(in, end, fb);
+}
+
+template <class InputIterator>
+uchar chars_to_uchar(InputIterator& in, InputIterator end, fallback_base& fb)
+{
+  return detail::chars_to_uchar_impl(in, end, fb);
 }
 
 // uchar -> char[] conversion

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -239,3 +239,160 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_surrogate)
       }, std::invalid_argument) << FormatByteSequence(str);
   }
 }
+
+const uchar replace_char = 0xFFFD;
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_are_empty)
+{
+  const char* p="";
+  EXPECT_EQ(0x0000, chars_to_uchar(p, p + strlen(p)));
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_single_byte_character_is_out_of_range)
+{
+  for (int c = 0x80; c <= 0xBF; c++) {
+    std::string str(1u, static_cast<char>(c));
+    const char* p=str.c_str();
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + str.size()));
+    EXPECT_EQ(str.c_str() + str.size(), p);
+  }
+  for (int c = 0xFE; c <= 0xFF; c++) {
+    std::string str(1u, static_cast<char>(c));
+    const char* p=str.c_str();
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + str.size()));
+    EXPECT_EQ(str.c_str() + str.size(), p);
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_have_a_5_byte_sequence)
+{
+  { // min 5-byte sequence
+    const char str[] = {'\xF8', '\x88', '\x80', '\x80', '\x80', '\x00'};
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+  { // max 5-byte sequence
+    const char str[] = {'\xFB', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_have_a_6_byte_sequence)
+{
+  { // min 6-byte sequence
+    const char str[] = {'\xFC', '\x84', '\x80', '\x80', '\x80', '\x80', '\x00'};
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+  { // max 6-byte sequence
+    const char str[] = {'\xFD', '\xBF', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_end_with_incomplete_byte_sequence)
+{
+  {
+    const char str[] = {'\xE3', '\x00'}; // 2 bytes are missing
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+  {
+    const char str[] = {'\xE3', '\x80', '\x00'}; // 1 byte is missing
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_have_a_start_byte_not_enough_continuation_bytes)
+{
+  {
+    const char str[] = {'\xE3', '\x80', // 1 byte is missing here
+                        '\xE3', '\x80', '\x81', '\x00'};
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + 2, p);
+    EXPECT_EQ(0x3001, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_have_an_overlong_encoding)
+{
+  { // Example of an overlong ASCII character('/')
+    const char str[3][5] = {
+      {'\xC0', '\xAF', '\x00'},
+      {'\xE0', '\x80', '\xAF', '\x00'},
+      {'\xF0', '\x80', '\x80', '\xAF', '\x00'},
+    };
+    for (size_t i = 0; i < 3; i++) {
+      const char* p=str[i];
+      EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+      EXPECT_EQ(str[i] + strlen(str[i]), p);
+    }
+  }
+  { // Minimum overlong sequences (NUL character)
+    const char str[3][5] = {
+      {'\xC0', '\x80', '\x00'},
+      {'\xE0', '\x80', '\x80', '\x00'},
+      {'\xF0', '\x80', '\x80', '\x80', '\x00'},
+    };
+    for (size_t i = 0; i < 3; i++) {
+      const char* p=str[i];
+      EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+      EXPECT_EQ(str[i] + strlen(str[i]), p);
+    }
+  }
+  { // Maximum overlong sequences
+    const char str[3][5] = {
+      {'\xC1', '\xBF', '\x00'},
+      {'\xE0', '\x9F', '\xBF', '\x00'},
+      {'\xF0', '\x8F', '\xBF', '\xBF', '\x00'},
+    };
+    for (size_t i = 0; i < 3; i++) {
+      const char* p=str[i];
+      EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+      EXPECT_EQ(str[i] + strlen(str[i]), p);
+    }
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_have_an_invalid_4_byte_sequence)
+{
+  {
+    const char str[] = {'\xF4', '\x8F', '\xBF', '\xBF', '\x00'}; // U+10FFFF
+    const char* p=str;
+    EXPECT_EQ(0x10FFFF, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+  {
+    const char str[] = {'\xF4', '\x90', '\x80', '\x80', '\x00'}; // U+110000
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+}
+
+TEST(ustring_utf_8_decode_replacement_test, utf_8_byte_sequences_have_a_surrogate)
+{
+  {
+    const char str[] = {'\xED', '\xA0', '\x80', '\x00'}; // U+D800
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+  {
+    const char str[] = {'\xED', '\xBF', '\xBF', '\x00'}; // U+DFFF
+    const char* p=str;
+    EXPECT_EQ(replace_char, chars_to_uchar(p, p + strlen(p)));
+    EXPECT_EQ(str + strlen(str), p);
+  }
+}

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -55,10 +55,10 @@ std::string FormatByteSequence(const char* str)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_are_empty)
 {
   const char* p="";
-  EXPECT_THROW({
+  EXPECT_NO_THROW({
       exception_fallback fb;
       chars_to_uchar(p, p + strlen(p), fb);
-    }, std::invalid_argument);
+    });
 }
 
 TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -55,7 +55,10 @@ std::string FormatByteSequence(const char* str)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_are_empty)
 {
   const char* p="";
-  EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument);
+  EXPECT_THROW({
+      exception_fallback fb;
+      chars_to_uchar(p, p + strlen(p), fb);
+    }, std::invalid_argument);
 }
 
 TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)
@@ -63,14 +66,18 @@ TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)
   for (int c = 0x80; c < 0xBF; c++) {
     std::string str(1u, static_cast<char>(c));
     const char* p=str.c_str();
-    EXPECT_THROW({chars_to_uchar(p, p + str.size());}, std::invalid_argument)
-      << FormatByteSequence(str.c_str());
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + str.size(), fb);
+      }, std::invalid_argument) << FormatByteSequence(str.c_str());
   }
   for (int c = 0xFE; c <= 0xFF; c++) {
     std::string str(1u, static_cast<char>(c));
     const char* p=str.c_str();
-    EXPECT_THROW({chars_to_uchar(p, p + str.size());}, std::invalid_argument)
-      << FormatByteSequence(str.c_str());
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + str.size(), fb);
+      }, std::invalid_argument) << FormatByteSequence(str.c_str());
   }
 }
 
@@ -79,14 +86,18 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_5_byte_sequence)
   { // min 5-byte sequence
     const char str[] = {'\xF8', '\x80', '\x80', '\x80', '\x80', '\x00'};
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
   { // max 5-byte sequence
     const char str[] = {'\xFB', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
 }
 
@@ -95,14 +106,18 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
   { // min 6-byte sequence
     const char str[] = {'\xFC', '\x80', '\x80', '\x80', '\x80', '\x00'};
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
   { // max 6-byte sequence
     const char str[] = {'\xFD', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
 }
 
@@ -111,14 +126,18 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_end_with_imcomplete_byte_se
   {
     const char str[] = {'\xE3', '\x00'}; // 2 bytes are missing
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
   {
     const char str[] = {'\xE3', '\x80', '\x00'}; // 1 byte is missing
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
 }
 
@@ -128,8 +147,10 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_start_byte_not_enoug
     const char str[] = {'\xE3', '\x80', // 1 byte is missing here
                         '\xE3', '\x80', '\x81', '\x00'};
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
 }
 
@@ -143,8 +164,10 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
-      EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-        << FormatByteSequence(str[i]);
+      EXPECT_THROW({
+          exception_fallback fb;
+          chars_to_uchar(p, p + strlen(p), fb);
+        }, std::invalid_argument) << FormatByteSequence(str[i]);
     }
   }
   { // Minimum overlong sequences (NUL character)
@@ -155,8 +178,10 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
-      EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-        << FormatByteSequence(str[i]);
+      EXPECT_THROW({
+          exception_fallback fb;
+          chars_to_uchar(p, p + strlen(p), fb);
+        }, std::invalid_argument) << FormatByteSequence(str[i]);
     }
   }
   { // Maximum overlong sequences
@@ -167,8 +192,10 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
     };
     for (size_t i = 0; i < 3; i++) {
       const char* p=str[i];
-      EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-        << FormatByteSequence(str[i]);
+      EXPECT_THROW({
+          exception_fallback fb;
+          chars_to_uchar(p, p + strlen(p), fb);
+        }, std::invalid_argument) << FormatByteSequence(str[i]);
     }
   }
 }
@@ -178,14 +205,18 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_invalid_4_byte_sequ
   {
     const char str[] = {'\xF4', '\x8F', '\x8F', '\x8F', '\x00'}; // U+10FFFF
     const char* p=str;
-    EXPECT_NO_THROW(chars_to_uchar(p, p + strlen(p)))
-      << FormatByteSequence(str);
+    EXPECT_NO_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }) << FormatByteSequence(str);
   }
   {
     const char str[] = {'\xF4', '\x90', '\x80', '\x80', '\x00'}; // U+110000
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
 }
 
@@ -194,13 +225,17 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_surrogate)
   {
     const char str[] = {'\xED', '\xA0', '\x80', '\x00'}; // U+D800
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
   {
     const char str[] = {'\xED', '\xBF', '\xBF', '\x00'}; // U+DFFF
     const char* p=str;
-    EXPECT_THROW({chars_to_uchar(p, p + strlen(p));}, std::invalid_argument)
-      << FormatByteSequence(str);
+    EXPECT_THROW({
+        exception_fallback fb;
+        chars_to_uchar(p, p + strlen(p), fb);
+      }, std::invalid_argument) << FormatByteSequence(str);
   }
 }

--- a/src/data/string/ustring_utf_8_decode_test.cpp
+++ b/src/data/string/ustring_utf_8_decode_test.cpp
@@ -63,7 +63,7 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_are_empty)
 
 TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)
 {
-  for (int c = 0x80; c < 0xBF; c++) {
+  for (int c = 0x80; c <= 0xBF; c++) {
     std::string str(1u, static_cast<char>(c));
     const char* p=str.c_str();
     EXPECT_THROW({
@@ -84,7 +84,7 @@ TEST(ustring_utf_8_decode_test, utf_8_single_byte_character_is_out_of_range)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_5_byte_sequence)
 {
   { // min 5-byte sequence
-    const char str[] = {'\xF8', '\x80', '\x80', '\x80', '\x80', '\x00'};
+    const char str[] = {'\xF8', '\x88', '\x80', '\x80', '\x80', '\x00'};
     const char* p=str;
     EXPECT_THROW({
         exception_fallback fb;
@@ -104,7 +104,7 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_5_byte_sequence)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
 {
   { // min 6-byte sequence
-    const char str[] = {'\xFC', '\x80', '\x80', '\x80', '\x80', '\x00'};
+    const char str[] = {'\xFC', '\x84', '\x80', '\x80', '\x80', '\x80', '\x00'};
     const char* p=str;
     EXPECT_THROW({
         exception_fallback fb;
@@ -112,7 +112,7 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
       }, std::invalid_argument) << FormatByteSequence(str);
   }
   { // max 6-byte sequence
-    const char str[] = {'\xFD', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
+    const char str[] = {'\xFD', '\xBF', '\xBF', '\xBF', '\xBF', '\xBF', '\x00'};
     const char* p=str;
     EXPECT_THROW({
         exception_fallback fb;
@@ -121,7 +121,7 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_a_6_byte_sequence)
   }
 }
 
-TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_end_with_imcomplete_byte_sequence)
+TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_end_with_incomplete_byte_sequence)
 {
   {
     const char str[] = {'\xE3', '\x00'}; // 2 bytes are missing
@@ -203,7 +203,7 @@ TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_overlong_encoding)
 TEST(ustring_utf_8_decode_test, utf_8_byte_sequences_have_an_invalid_4_byte_sequence)
 {
   {
-    const char str[] = {'\xF4', '\x8F', '\x8F', '\x8F', '\x00'}; // U+10FFFF
+    const char str[] = {'\xF4', '\x8F', '\xBF', '\xBF', '\x00'}; // U+10FFFF
     const char* p=str;
     EXPECT_NO_THROW({
         exception_fallback fb;


### PR DESCRIPTION
This pull request contains following changes:

* pfi::data::string::chars_to_uchar and pfi::data::string::string_to_ustring become not to throw exceptions by defalut.
  * Invalid byte sequences are replaced with replace character(U+FFFD). 
* Added fallback interface to pfi::data::string::chars_to_uchar. We can select behaviour when invalid byte sequence is given (ex. throwing exceptions)
* Fixed some wrong tests for UTF-8 decoding.

We should add fallback interfaces to pfi::data::string::string_to_ustring and pfi::data::string::string_to_uchar...?
