### PR TITLE
Fixed pfi::network::mprpc not to time out when timeout_sec is 0

### DIFF
--- a/src/network/mprpc/object_stream.cpp
+++ b/src/network/mprpc/object_stream.cpp
@@ -84,7 +84,8 @@ int object_stream::read(msgpack::object* obj, std::auto_ptr<msgpack::zone>* zone
       if(rl > 0) break;
       if(rl == 0) { return -1; }
       if(errno == EINTR) { continue; }
-      if(timeout_sec < (double)(get_clock_time() - start)){
+      if(timeout_sec > 0.0 &&
+         timeout_sec < (double)(get_clock_time() - start)){
         throw rpc_timeout_error("timeout");
       }
       if(errno == EAGAIN) { continue; }
@@ -107,7 +108,8 @@ int object_stream::write(const void* data, size_t size, double timeout_sec)
         return -1;
       }
       if(errno == EINTR) { continue; }
-      if(timeout_sec < (double)(get_clock_time() - start)){
+      if(timeout_sec > 0.0 &&
+         timeout_sec < (double)(get_clock_time() - start)){
         throw rpc_timeout_error("timeout");
       }
       if(errno == EAGAIN) { continue; }

--- a/src/network/mprpc/socket.cpp
+++ b/src/network/mprpc/socket.cpp
@@ -242,6 +242,9 @@ bool socket::set_timeout_sockopt(int sock, int optname, double sec)
 {
   if(sock < 0) { return false; }
 
+  if (sec < 0) {
+    sec = 0.0;
+  }
   timeval tv;
   tv.tv_sec = std::max(0,(int)sec);
   tv.tv_usec = std::min(999999, std::max(0,(int)((sec-tv.tv_sec)*1e6)));

--- a/src/network/mprpc/socket.cpp
+++ b/src/network/mprpc/socket.cpp
@@ -242,9 +242,6 @@ bool socket::set_timeout_sockopt(int sock, int optname, double sec)
 {
   if(sock < 0) { return false; }
 
-  if (sec < 0) {
-    sec = 0.0;
-  }
   timeval tv;
   tv.tv_sec = std::max(0,(int)sec);
   tv.tv_usec = std::min(999999, std::max(0,(int)((sec-tv.tv_sec)*1e6)));


### PR DESCRIPTION
Current server and client of pfi::network::mprpc time out immediately when timeout_sec is 0 or smaller than 0.
This PR fixes this problem.
