### PR TITLE
Fixed build scripts not to check <ext/hash_map> and <ext/hash_set>

### DIFF
--- a/doc/source/data/unordered_map.rst
+++ b/doc/source/data/unordered_map.rst
@@ -6,9 +6,8 @@ pfi::data::unordered_map
 ====
 
 C++0xのstd::unordered_mapと同一のインターフェースを提供するコンテナ。
-<ext/hash_map>、<tr1/unordered_map>、<unordered_map>
+<tr1/unordered_map>、<unordered_map>
 のうち、存在する実装を利用し、これらのインターフェースの違いを吸収する。
-<ext/hash_map>が利用される場合も、標準的な型のデフォルトハッシュ関数が利用できる。
 
 使い方
 ======

--- a/src/data/wscript
+++ b/src/data/wscript
@@ -5,10 +5,8 @@ def configure(conf):
 
   conf.check_cxx(header_name = 'unordered_map', mandatory = False)
   conf.check_cxx(header_name = 'tr1/unordered_map', mandatory = False)
-  conf.check_cxx(header_name = 'ext/hash_map', mandatory = False)
   conf.check_cxx(header_name = 'unordered_set', mandatory = False)
   conf.check_cxx(header_name = 'tr1/unordered_set', mandatory = False)
-  conf.check_cxx(header_name = 'ext/hash_set', mandatory = False)
 
 def build(bld):
   bld.install_files('${HPREFIX}/data', [


### PR DESCRIPTION
Because they are no longer used.