### PR TITLE
[ustring] use iterator for std::string interface

### DIFF
--- a/src/data/string/ustring.cpp
+++ b/src/data/string/ustring.cpp
@@ -88,14 +88,22 @@ static int take_handakuten_tbl[]={
 };
 
 ustring string_to_ustring(const char* p) {
-  const char* const end = p + strlen(p);
+  return string_to_ustring(p, strlen(p));
+}
+
+ustring string_to_ustring(const char* p, size_t len) {
+  const char* const end = p + len;
   ustring res;
-  while(*p) res+=chars_to_uchar(p, end);
+  while(p != end) res+=chars_to_uchar(p, end);
   return res;
 }
 
 ustring string_to_ustring(const std::string& s) {
-  return string_to_ustring(s.c_str());
+  ustring res;
+  for (std::string::const_iterator it = s.begin(), end = s.end(); it != end; ) {
+    res += chars_to_uchar(it, end);
+  }
+  return res;
 }
 
 std::string ustring_to_string(const ustring& us) {

--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -67,7 +67,8 @@ public:
 };
 
 // string <-> ustring conversion
-ustring string_to_ustring(const char* p);
+ustring string_to_ustring(const char* p);  // assume null-terminated string
+ustring string_to_ustring(const char* p, size_t len);
 ustring string_to_ustring(const std::string& s);
 std::string ustring_to_string(const ustring& us);
 

--- a/src/data/string/ustring_test.cpp
+++ b/src/data/string/ustring_test.cpp
@@ -56,6 +56,24 @@ TEST(string_test, cast) {
   EXPECT_TRUE(string_to_ustring("el")==xs);
 }
 
+TEST(string_test, string_to_ustring_char_interface) {
+  std::string str("foo\0bar", 7);
+  ustring ustr = string_to_ustring(str.c_str());
+  EXPECT_EQ(3u, ustr.size());  // "foo"
+}
+
+TEST(string_test, string_to_ustring_char_interface_with_len) {
+  std::string str("foo\0bar", 7);
+  ustring ustr = string_to_ustring(str.c_str(), str.size());
+  EXPECT_EQ(7u, ustr.size());  // "foo\0bar"
+}
+
+TEST(string_test, string_to_ustring_std_string_interface) {
+  std::string str("foo\0bar", 7);
+  ustring ustr = string_to_ustring(str);
+  EXPECT_EQ(7u, ustr.size());  // "foo\0bar"
+}
+
 TEST(ustring_test, basic) {
   const char* p="私の名前は中野です。";
   string s=p;


### PR DESCRIPTION
`.c_str()` is quite an old interface for C++.
`std::string` interface should use iterator instead.
Also define pointer+length interface for `char *`.


// which is better? -- stop on `\0` or keep going till `.end()`