### PR TITLE
[wscript] libpath should be array

### DIFF
--- a/src/database/wscript
+++ b/src/database/wscript
@@ -28,7 +28,7 @@ def configure(conf):
       if conf.check_cxx(lib = 'pq',
                         header_name = 'postgres.h',
                         cxxflags = [ '-I' + incdir ],
-                        libpath = libdir,
+                        libpath = [ libdir ],
                         uselib_store = 'PGSQL',
                         mandatory = False):
         conf.env.BUILD_PGSQL = True


### PR DESCRIPTION
save as #164
libpath should be array
```
  '-Lsrc/math',
  '-Lsrc/visualization',
  u'-L/', u'-Lu', u'-Ls', u'-Lr', u'-Ll', u'-Li', u'-Lb', u'-L6', u'-L4',
  '-lpficommon',
  '-lpficommon_network_cgi',
  '-lpficommon_network_http',
```
↓
```
  '-Lsrc/math',
  '-Lsrc/visualization',
  u'-L/usr/lib64',
  '-lpficommon',
  '-lpficommon_network_cgi',
  '-lpficommon_network_http',
```