### PR TITLE
Fixed ustring.h not to output warnings for unused variables

### DIFF
--- a/src/data/string/ustring.h
+++ b/src/data/string/ustring.h
@@ -109,7 +109,7 @@ public:
   }
 
   virtual uchar fallback(const std::string& bytes,
-                         const char* hint) {
+                         const char* /*hint*/) {
     if (bytes.empty()) {
       return 0x0000;
     }


### PR DESCRIPTION
Because the pfi::data::string::replacement_fallback does not use the "hint" argument.