### PR TITLE
Fixed wscript to output -lmsgpack to Libs section in pficommon.pc

### DIFF
--- a/wscript
+++ b/wscript
@@ -89,6 +89,8 @@ def build(bld):
   ls = ''
   for l in set(libs):
     ls = ls + ' -l' + l
+  if bld.env.BUILD_MPRPC:
+    ls = ls + ' -lmsgpack'
 
   bld(source = 'pficommon.pc.in',
       prefix = bld.env['PREFIX'],


### PR DESCRIPTION
If user use pfi::network::mprpc, user must link msgpack due to the dependency from pficommon to msgpack. This should be done by pkg-config(pficommon.pc), so this patch do it.

In fact, in DSO linking enalbed environments, failed to link msgpack. In Ubuntu 11.10 and RHEL 7(CentOS 7) or later, DSO linking is enabled.

before:

```
$ g++ `pkg-config --cflags pficommon` `pkg-config --libs pficommon` server_test.cpp
/usr/bin/ld: /tmp/cchw0dTz.o: シンボル '_ZN7msgpacklsERSoNS_6objectE' への未定義参照です
/usr/bin/ld: 注: '_ZN7msgpacklsERSoNS_6objectE' は DSO /home/eiichiro/local/lib/libmsgpack.so.3 内で定義されているのでリンカのコマンドラインに追加してみてください
/home/eiichiro/local/lib/libmsgpack.so.3: could not read symbols: 無効な操作です
collect2: エラー: ld はステータス 1 で終了しました
```
