### PR TITLE
Update README.ja.rst

### DIFF
--- a/README.ja.rst
+++ b/README.ja.rst
@@ -18,3 +18,11 @@ C++用汎用ライブラリです。GCC 4.1.2 以降対応。
   $ ./waf build
   $ ./waf install
 
+
+Tips
+====
+  - ./waf install は 権限が足らずに失敗する場合がある。　その際は、su なり sudo なりで 必要な権限を与えること。
+  
+  - pkg-config のパスが通ってなくて、pficommonを使用する プロジェクトの .configure が通らない事がある
+  - その時には、"export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig" (例) で 環境変数を設定すること。 
+  - ↑は CentOS 7 での例。 他の環境では path が異なる場合がある。 環境に合った pkgconfig ディレクトリの位置を指定すること。


### PR DESCRIPTION
pficommon を 手元の環境に clone して、自前のプロジェクトから使用しようとしたときに、躓いた or 躓きそうに思えた所の 回避方法を Tip として記述しました。

改行 や インデントが マークダウン記述を試したのですが 思った様にいかないのですね…。