### PR TITLE
Fix stream size

### DIFF
--- a/src/network/socket.h
+++ b/src/network/socket.h
@@ -65,9 +65,9 @@ public:
   const ipv4_address &remote_addr() const;
   uint16_t remote_port() const;
 
-  int read(void *dat, int size);
-  int write(const void *dat, int size);
-  int flush();
+  ssize_t read(void *dat, size_t size);
+  ssize_t write(const void *dat, size_t size);
+  ssize_t flush();
 
   int getc();
   bool getline(std::string &str, int limit=-1);
@@ -88,9 +88,9 @@ private:
   bool open();
   bool close();
 
-  int recv(void *dat, int size);
-  int send(const void *dat, int size);
-  int send_all(const void *dat, int size);
+  ssize_t recv(void *dat, size_t size);
+  ssize_t send(const void *dat, size_t size);
+  ssize_t send_all(const void *dat, size_t size);
 
   bool bind_socket(int sock);
   bool bind_socket(int sock, const ipv4_address &addr, uint16_t port);
@@ -103,13 +103,13 @@ private:
 
   void fill_buf();
   int inc_buf();
-  int buf_elem();
+  size_t buf_elem();
 
   std::vector<unsigned char> rdbuf;
-  int rdbuf_p, rdbuf_end;
+  ssize_t rdbuf_p, rdbuf_end;
 
   std::vector<unsigned char> wrbuf;
-  int wrbuf_size;
+  ssize_t wrbuf_size;
 
   static pfi::lang::shared_ptr<dns_resolver> resolver;
   static pfi::concurrent::r_mutex resolver_m;

--- a/src/network/socket_test.cpp
+++ b/src/network/socket_test.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+#include "socket.h"
+
+#include "../lang/bind.h"
+#include "../concurrent/thread.h"
+#include "../concurrent/mvar.h"
+
+using namespace pfi::network;
+
+struct server_info {
+  server_info() {}
+
+  pfi::concurrent::mvar<bool> is_accepted;
+  pfi::concurrent::mvar<std::string> first_line;
+  pfi::concurrent::mvar<size_t> send_size;
+  pfi::concurrent::mvar<size_t> read_size;
+};
+
+static void server_thread(pfi::lang::shared_ptr<server_socket> server, server_info* server_info) {
+  pfi::lang::shared_ptr<stream_socket> sock(server->accept());
+
+  sock->set_timeout(10);
+  server_info->is_accepted.put(true);
+
+  // read line
+  std::string line;
+  sock->getline(line);
+  server_info->first_line.put(line);
+
+  // read buffer
+  std::vector<char> buffer(1024);
+  size_t send_size = server_info->send_size.take();
+  size_t read_size = 0;
+  while (read_size < send_size && sock->is_connected()) {
+    size_t r = sock->read(buffer.data(), buffer.size());
+    read_size += r;
+    if (r < buffer.size()) break;  // reach EOF
+  }
+  server_info->read_size.put(read_size);
+}
+
+TEST(socket_server_client, server_test) {
+  pfi::lang::shared_ptr<server_socket> server(new server_socket());
+  server->set_timeout(10);
+  EXPECT_TRUE(server->create(0));
+  int port = server->port();
+  EXPECT_LT(1024, port);  // ephemeral port
+
+  server_info server_info;
+  pfi::concurrent::thread t(pfi::lang::bind(&server_thread, server, &server_info));
+  t.start();
+
+  stream_socket ss;
+  EXPECT_TRUE(ss.connect("127.0.0.1", port));
+
+  // server accepted
+  EXPECT_TRUE(server_info.is_accepted.take());
+  EXPECT_TRUE(ss.is_connected());
+
+  EXPECT_EQ("127.0.0.1", ss.remote_addr().to_string());
+  EXPECT_EQ(port, ss.remote_port());
+
+  EXPECT_TRUE(ss.puts("hello\n"));
+  EXPECT_EQ(-1, ss.flush());
+
+  // wait server read
+  EXPECT_EQ("hello", server_info.first_line.take());
+
+  size_t send_size = 2ul * 1024 * 1024 * 1024 + 42;  // > sizeof(int32)
+  server_info.send_size.put(send_size);
+
+  std::vector<char> huge_buffer(send_size);
+  EXPECT_EQ(send_size, ss.write(huge_buffer.data(), huge_buffer.size()));
+
+  // wait server read
+  EXPECT_EQ(send_size, server_info.read_size.take());
+
+  ss.shutdown();
+
+  t.join();
+}

--- a/src/network/wscript
+++ b/src/network/wscript
@@ -115,6 +115,13 @@ def build(bld):
 
   bld.program(
     features = 'gtest',
+    source = 'socket_test.cpp',
+    target = 'socket_test',
+    includes = '.',
+    use = 'pficommon_network')
+
+  bld.program(
+    features = 'gtest',
     source = 'uri_test.cpp',
     target = 'uri_test',
     includes = '.',


### PR DESCRIPTION
```
ssize_t recv(int sockfd, void *buf, size_t len, int flags);
ssize_t send(int sockfd, const void *buf, size_t len, int flags);
ssize_t write(int fd, const void *buf, size_t count);
ssize_t read(int fd, void *buf, size_t count);
```

buffer length should be `size_t`.
This prevents the CGI server from returning a body larger than 2GiB.

